### PR TITLE
ci: install node_modules before publishing to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,8 +65,19 @@ jobs:
       # Published through `nix develop` because the build needs third-party/utif,
       # which the dev shell symlinks in from the `utif` flake input. A bare
       # `npm ci && npm publish` on a plain checkout would fail to resolve it.
+      #
+      # `npm ci` is not redundant with the dev shell: the shell supplies the
+      # toolchain and the utif symlink, never node_modules. Without it the
+      # prepublishOnly build ran against an empty tree and tsc failed on the
+      # first bare-specifier import it hit (@privyid/ghostscript, exifreader).
+      # It got as far as running at all only because a `tsc` further up $PATH
+      # stood in for the missing node_modules/.bin one.
       - name: Publish @avunu/thumbnailer
         if: ${{ steps.release.outputs.release_created }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: nix develop --no-pure-eval --command npm publish
+        run: |
+          nix develop --no-pure-eval --command bash -c '
+            npm ci
+            npm publish
+          '


### PR DESCRIPTION
The publish step ran `npm publish` on a fresh checkout with nothing
installed. The dev shell supplies the toolchain and the third-party/utif
symlink, but never node_modules, so prepublishOnly's build hit tsc
against an empty tree and died on the first bare-specifier imports:
@privyid/ghostscript and exifreader.

The error read like dependency resolution rather than a missing install
because, with no node_modules/.bin, `npm run` fell through to a tsc
further up $PATH instead of failing with "command not found".

The step had never actually run before: the two earlier green Release
runs were ordinary pushes to main, where release_created is false and
everything after release-please skips. Merging the first release-please
PR was the first time it executed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
